### PR TITLE
find_properties: also find aliases

### DIFF
--- a/lib/find_properties.js
+++ b/lib/find_properties.js
@@ -21,7 +21,7 @@ const findExternalIdsProperties = str => {
   str = _.replaceUnderscoresBySpaces(str)
   const re = new RegExp(str, 'i')
   return externalIds
-  .filter(prop => prop.label.match(re))
+  .filter(prop => prop.label.match(re) || prop.aliases.match(re))
   .map(prop => prop.property)
 }
 

--- a/scripts/assets/properties.rq
+++ b/scripts/assets/properties.rq
@@ -1,4 +1,4 @@
-SELECT ?property ?label ?type ?urlFormat
+SELECT ?property ?label ?type ?urlFormat (GROUP_CONCAT(?alias;separator='\n') AS ?aliases)
 WHERE {
   ?property a wikibase:Property .
   ?property wikibase:propertyType ?propertyType .
@@ -8,5 +8,10 @@ WHERE {
   # and not { value, label }
   ?property rdfs:label ?label .
   FILTER((LANG(?label)) = "en")
+  OPTIONAL {
+    ?property skos:altLabel ?alias .
+    FILTER((LANG(?alias)) = "en")
+  }
 }
+GROUP BY ?property ?label ?type ?urlFormat
 ORDER BY ASC(xsd:integer(STRAFTER(STR(?property), 'P')))


### PR DESCRIPTION
For instance P1184 ("Handle") is also be abbreviated as "hdl", e.g.

    /hdl:10462/eadarc/7154