### PR TITLE
generate_properties_index: include selected string properties

### DIFF
--- a/scripts/assets/properties.rq
+++ b/scripts/assets/properties.rq
@@ -1,4 +1,4 @@
-SELECT ?property ?label ?type ?urlFormat (GROUP_CONCAT(?alias;separator='\n') AS ?aliases)
+SELECT ?property ?label ?type ?urlFormat ?authority (GROUP_CONCAT(?alias;separator='\n') AS ?aliases)
 WHERE {
   ?property a wikibase:Property .
   ?property wikibase:propertyType ?propertyType .
@@ -12,6 +12,10 @@ WHERE {
     ?property skos:altLabel ?alias .
     FILTER((LANG(?alias)) = "en")
   }
+  OPTIONAL {
+    ?property wdt:P31/wdt:P279* wd:Q18614948 .
+    BIND (TRUE AS ?authority)
+  }
 }
-GROUP BY ?property ?label ?type ?urlFormat
+GROUP BY ?property ?label ?type ?urlFormat ?authority
 ORDER BY ASC(xsd:integer(STRAFTER(STR(?property), 'P')))

--- a/scripts/generate_properties_index
+++ b/scripts/generate_properties_index
@@ -41,7 +41,8 @@ const indexWord = (property, word) => {
 }
 
 for (let property in properties) {
-  if (properties[property].type === 'ExternalId') {
+  const { type, authority } = properties[property]
+  if (type === 'ExternalId' || (type === 'String' && authority)) {
     indexPropertyByLabel(property)
     indexPropertyByAliases(property)
   }


### PR DESCRIPTION
Wikidata properties for authority control (Q18614948) are used for
identification but around 50 of these properties have type String
instead of ExternalId. This change adds supports for instance of

* isil:DE-1 (Library Identifier)
* faa:BTV (FAA airport code)